### PR TITLE
Use `atom-text-editor` tag instead of `editor` class.

### DIFF
--- a/index.less
+++ b/index.less
@@ -1,30 +1,30 @@
-.editor, .editor .gutter {
+atom-text-editor, atom-text-editor .gutter {
   background-color: #FFFFFF;
   color: #000000;
 }
 
-.editor .indent-guide {
+atom-text-editor .indent-guide {
   box-shadow: 1px 0 rgba(0, 0, 0, 0.2);
 
 }
 
-.editor .wrap-guide {
+atom-text-editor .wrap-guide {
     background: rgba(0, 0, 0, 0.2);
 }
 
-.editor .invisible-character {
+atom-text-editor .invisible-character {
     color: rgba(0, 0, 0, 0.7);
 }
 
-.editor.is-focused .cursor {
+atom-text-editor.is-focused .cursor {
   border-color: #000000;
 }
 
-.editor.is-focused .selection .region {
+atom-text-editor.is-focused .selection .region {
   background-color: #A6CBFF;
 }
 
-.editor.is-focused .line-number.cursor-line-no-selection, .editor.is-focused .line.cursor-line {
+atom-text-editor.is-focused .line-number.cursor-line-no-selection, atom-text-editor.is-focused .line.cursor-line {
   background-color: rgba(255, 225, 53, 0.3);
 }
 

--- a/index.less
+++ b/index.less
@@ -1,30 +1,40 @@
-atom-text-editor, atom-text-editor .gutter {
+atom-text-editor,
+atom-text-editor::shadow,
+atom-text-editor .gutter,
+atom-text-editor::shadow .gutter {
   background-color: #FFFFFF;
   color: #000000;
 }
 
-atom-text-editor .indent-guide {
+atom-text-editor .indent-guide,
+atom-text-editor::shadow .indent-guide {
   box-shadow: 1px 0 rgba(0, 0, 0, 0.2);
-
 }
 
-atom-text-editor .wrap-guide {
+atom-text-editor .wrap-guide,
+atom-text-editor::shadow .wrap-guide {
     background: rgba(0, 0, 0, 0.2);
 }
 
-atom-text-editor .invisible-character {
+atom-text-editor .invisible-character,
+atom-text-editor::shadow .invisible-character {
     color: rgba(0, 0, 0, 0.7);
 }
 
-atom-text-editor.is-focused .cursor {
+atom-text-editor.is-focused .cursor,
+atom-text-editor.is-focused::shadow .cursor {
   border-color: #000000;
 }
 
-atom-text-editor.is-focused .selection .region {
+atom-text-editor.is-focused .selection .region,
+atom-text-editor.is-focused::shadow .selection .region {
   background-color: #A6CBFF;
 }
 
-atom-text-editor.is-focused .line-number.cursor-line-no-selection, atom-text-editor.is-focused .line.cursor-line {
+atom-text-editor.is-focused .line-number.cursor-line-no-selection,
+atom-text-editor.is-focused::shadow .line-number.cursor-line-no-selection,
+atom-text-editor.is-focused .line.cursor-line,
+atom-text-editor.is-focused::shadow .line.cursor-line {
   background-color: rgba(255, 225, 53, 0.3);
 }
 


### PR DESCRIPTION
This fixes the 'Use the `atom-text-editor` tag instead of the `editor` class.' warning.

![screenshot 2015-03-27 14 20 46](https://cloud.githubusercontent.com/assets/6295938/6875529/6d059c76-d48d-11e4-8a87-95242e85e0d9.png)

Hope it helps!