### PR TITLE
Fix C preprocessor highlight incorrectly

### DIFF
--- a/index.less
+++ b/index.less
@@ -175,3 +175,10 @@ atom-text-editor.is-focused::shadow .line.cursor-line {
 .markup.quote {
   color:#7C4625;
 }
+
+.c.preprocessor {
+  .punctuation.definition.keyword,
+  .preprocessor.name {
+    color: #7C4625;
+  }
+}


### PR DESCRIPTION
Hi

I send a pr about highlight c preprocessor incorrectly compare to XCode 

this is Atom xcode-theme highlight currently:

<img width="227" alt="screen shot 2558-10-27 at 10 29 51 pm" src="https://cloud.githubusercontent.com/assets/484530/10762874/62aa51de-7cfa-11e5-92af-8d2fd645f0a9.png">

this is XCode highlight:

<img width="238" alt="screen shot 2558-10-27 at 10 26 31 pm" src="https://cloud.githubusercontent.com/assets/484530/10762900/72baecaa-7cfa-11e5-8101-13945a56cf10.png">
